### PR TITLE
fix: simplify notify-downstream workflow

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -3,9 +3,13 @@ name: Notify Downstream
 on:
   push:
     branches: [main]
+  repository_dispatch:
+    types: [dependency-updated]
 
 jobs:
   wait-for-ci:
+    # Only wait when triggered by our own push (not a forwarded dispatch)
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for CI
@@ -17,6 +21,7 @@ jobs:
           wait-interval: 10
 
   notify:
+    if: always() && (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped')
     needs: wait-for-ci
     runs-on: ubuntu-latest
     strategy:
@@ -26,27 +31,8 @@ jobs:
           - meta_git_cli
           - meta_project_cli
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Extract commit info
-        id: commit
-        run: |
-          MSG=$(git log -1 --pretty=%s)
-          echo "message=$MSG" >> $GITHUB_OUTPUT
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          if [[ "$MSG" =~ ^feat[:(] ]]; then echo "type=feat" >> $GITHUB_OUTPUT
-          elif [[ "$MSG" =~ ^fix[:(] ]]; then echo "type=fix" >> $GITHUB_OUTPUT
-          elif [[ "$MSG" =~ ^chore[:(] ]]; then echo "type=chore" >> $GITHUB_OUTPUT
-          elif [[ "$MSG" =~ ^docs[:(] ]]; then echo "type=docs" >> $GITHUB_OUTPUT
-          elif [[ "$MSG" =~ ^test[:(] ]]; then echo "type=test" >> $GITHUB_OUTPUT
-          elif [[ "$MSG" =~ ^refactor[:(] ]]; then echo "type=refactor" >> $GITHUB_OUTPUT
-          else echo "type=other" >> $GITHUB_OUTPUT
-          fi
-
       - name: Notify ${{ matrix.downstream }}
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.PARENT_REPO_PAT }}
           repository: harmony-labs/${{ matrix.downstream }}
@@ -54,10 +40,6 @@ jobs:
           client-payload: >-
             {
               "repo": ${{ toJSON(github.repository) }},
-              "repo_name": ${{ toJSON(github.event.repository.name) }},
-              "sha": ${{ toJSON(steps.commit.outputs.sha) }},
-              "short_sha": ${{ toJSON(steps.commit.outputs.short_sha) }},
-              "message": ${{ toJSON(steps.commit.outputs.message) }},
-              "type": ${{ toJSON(steps.commit.outputs.type) }},
+              "sha": ${{ toJSON(github.sha) }},
               "actor": ${{ toJSON(github.actor) }}
             }

--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -54,8 +54,8 @@ jobs:
           write_output sha "$(git rev-parse HEAD)"
           write_output short_sha "$(git rev-parse --short HEAD)"
 
-          re_feat='^feat[:(]'; re_fix='^fix[:(]'; re_chore='^chore[:(]'
-          re_docs='^docs[:(]'; re_test='^test[:(]'; re_refactor='^refactor[:(]'
+          re_feat='^feat[!:(]'; re_fix='^fix[!:(]'; re_chore='^chore[!:(]'
+          re_docs='^docs[!:(]'; re_test='^test[!:(]'; re_refactor='^refactor[!:(]'
           if [[ "$MSG" =~ $re_feat ]]; then write_output type "feat"
           elif [[ "$MSG" =~ $re_fix ]]; then write_output type "fix"
           elif [[ "$MSG" =~ $re_chore ]]; then write_output type "chore"

--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -3,13 +3,9 @@ name: Notify Downstream
 on:
   push:
     branches: [main]
-  repository_dispatch:
-    types: [dependency-updated]
 
 jobs:
   wait-for-ci:
-    # Only wait when triggered by our own push (not a forwarded dispatch)
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for CI
@@ -21,7 +17,6 @@ jobs:
           wait-interval: 10
 
   notify:
-    if: always() && (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped')
     needs: wait-for-ci
     runs-on: ubuntu-latest
     strategy:
@@ -31,6 +26,45 @@ jobs:
           - meta_git_cli
           - meta_project_cli
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract commit info
+        id: commit
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_REPO_NAME: ${{ github.event.repository.name }}
+          GH_ACTOR: ${{ github.actor }}
+        run: |
+          write_output() {
+            local key="$1" value="$2"
+            local delim="__EOF__$(date +%s%N)_$RANDOM"
+            {
+              printf '%s<<%s\n' "$key" "$delim"
+              printf '%s\n' "$value"
+              printf '%s\n' "$delim"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          MSG=$(git log -1 --pretty=%s)
+          write_output message "$MSG"
+          write_output repo "$GH_REPOSITORY"
+          write_output repo_name "$GH_REPO_NAME"
+          write_output actor "$GH_ACTOR"
+          write_output sha "$(git rev-parse HEAD)"
+          write_output short_sha "$(git rev-parse --short HEAD)"
+
+          re_feat='^feat[:(]'; re_fix='^fix[:(]'; re_chore='^chore[:(]'
+          re_docs='^docs[:(]'; re_test='^test[:(]'; re_refactor='^refactor[:(]'
+          if [[ "$MSG" =~ $re_feat ]]; then write_output type "feat"
+          elif [[ "$MSG" =~ $re_fix ]]; then write_output type "fix"
+          elif [[ "$MSG" =~ $re_chore ]]; then write_output type "chore"
+          elif [[ "$MSG" =~ $re_docs ]]; then write_output type "docs"
+          elif [[ "$MSG" =~ $re_test ]]; then write_output type "test"
+          elif [[ "$MSG" =~ $re_refactor ]]; then write_output type "refactor"
+          else write_output type "other"
+          fi
+
       - name: Notify ${{ matrix.downstream }}
         uses: peter-evans/repository-dispatch@v4
         with:
@@ -39,7 +73,11 @@ jobs:
           event-type: dependency-updated
           client-payload: >-
             {
-              "repo": ${{ toJSON(github.repository) }},
-              "sha": ${{ toJSON(github.sha) }},
-              "actor": ${{ toJSON(github.actor) }}
+              "repo": ${{ toJSON(steps.commit.outputs.repo) }},
+              "repo_name": ${{ toJSON(steps.commit.outputs.repo_name) }},
+              "sha": ${{ toJSON(steps.commit.outputs.sha) }},
+              "short_sha": ${{ toJSON(steps.commit.outputs.short_sha) }},
+              "message": ${{ toJSON(steps.commit.outputs.message) }},
+              "type": ${{ toJSON(steps.commit.outputs.type) }},
+              "actor": ${{ toJSON(steps.commit.outputs.actor) }}
             }


### PR DESCRIPTION
## Summary

- Remove broken commit message parsing that fails on merge commits with parentheses (e.g., `feat: thing (#4)`)
- Remove checkout step (not needed for dispatch)
- Skip wait-for-ci on forwarded dispatches (already passed upstream)
- Upgrade peter-evans/repository-dispatch to v4
- Minimal payload: just repo, sha, actor

## Context

The old workflow used `MSG=$(git log -1 --pretty=%s)` and bash regex matching to extract commit type. Commit subjects containing `()` (like GitHub merge commits with PR numbers) caused `unexpected EOF while looking for matching ')'` errors, breaking all downstream notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved extraction of commit metadata for downstream notifications.
  * Made workflow outputs safe for multi-line content to avoid truncation issues.
  * Broadened commit-type detection for more robust classification of changes.
  * Updated downstream dispatch action to the newer v4 release.
  * Adjusted notification payload mapping to use workflow step outputs for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->