### PR TITLE
fix(clippy): use sort_by_key with Reverse for descending sort

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -263,7 +263,7 @@ pub fn list_snapshots(meta_root: &Path) -> Result<Vec<SnapshotInfo>> {
     }
 
     // Sort by creation time, newest first
-    snapshots.sort_by(|a, b| b.created.cmp(&a.created));
+    snapshots.sort_by_key(|s| std::cmp::Reverse(s.created));
 
     Ok(snapshots)
 }


### PR DESCRIPTION
Caught by Rust 1.95.0's `unnecessary_sort_by` lint. Same pattern as [gitkb/meta_cli#23](https://github.com/gitkb/meta_cli/pull/23) — `sort_by(|a, b| b.cmp(&a))` is equivalent to `sort_by_key(|x| std::cmp::Reverse(x))`. `DateTime<Utc>` is `Copy`, so no allocation/clone concerns. Unblocks [gitkb/meta#78](https://github.com/gitkb/meta/pull/78).